### PR TITLE
fix #2

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -41,20 +41,14 @@ jobs:
     name: build docker image
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 20
+    env:
+      COMPONENT_NAME: "${{ inputs.component || github.event.repository.name }}"
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-
-      - name: 'use component inputs as component var'
-        if: ${{ inputs.component != ''}}
-        run: echo "COMPONENT_NAME=${{ inputs.component }}" >> $GITHUB_ENV
-
-      - name: 'set component var in case someone forget to set it'
-        if: ${{ inputs.component == ''}}
-        run: echo "COMPONENT_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
 
       # Scan repo for secrets
       - name: Run scanner for the repository

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -6,7 +6,8 @@ on:
         required: true
         type: string
       component:
-        required: true
+        # not required now
+        required: false
         type: string
       node_env:
         required: false
@@ -47,6 +48,14 @@ jobs:
         with:
           fetch-depth: "0"
 
+      - name: 'use component inputs as component var'
+        if: ${{ inputs.component != ''}}
+        run: echo "COMPONENT_NAME=${{ inputs.component }}" >> $GITHUB_ENV
+
+      - name: 'set component var in case someone forget to set it'
+        if: ${{ inputs.component == ''}}
+        run: echo "COMPONENT_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
+
       # Scan repo for secrets
       - name: Run scanner for the repository
         run: /usr/local/bin/whispers ${{ github.workspace }} > /tmp/scan_output.json
@@ -65,7 +74,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ secrets.REGISTRY }}/${{ inputs.project }}/${{ inputs.component }}
+          images: ${{ secrets.REGISTRY }}/${{ inputs.project }}/${{ env.COMPONENT_NAME }}
           tags: |
             type=edge
             type=ref,event=branch
@@ -88,8 +97,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            OMNI_COMPONENT=${{ inputs.component }}
+            OMNI_COMPONENT=${{ env.COMPONENT_NAME }}
             NODE_ENV=${{ inputs.node_env }}
             NPM_TOKEN=${{ secrets.NPM_TOKEN }}
             OMNI_COMPONENT_COMMIT=${{ github.sha }}
-            OMNI_COMPONENT_VERSION=${{ github.ref }}
+            OMNI_COMPONENT_VERSION=${{ steps.meta.outputs.version }}


### PR DESCRIPTION
- use steps.meta.outputs.version instead of github.ref which including `refs/tags` `refs/heads`
  it also replaces `/` with `-`
- make `component` not required, fallback to reponame without owner if not set

fixes #2