### PR TITLE
Upgrade the actions 

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: "0"
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -79,7 +79,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ inputs.project }}/${{ env.COMPONENT_NAME }}
           tags: |

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Login to PrivateRegistry
         # https://github.com/actions/runner/issues/1483
         if: ${{ inputs.push }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -98,7 +98,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD}}
 
       - name: Load to local registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         if: ${{ inputs.load }}
         with:
           context: ${{ inputs.docker_context }}
@@ -115,7 +115,7 @@ jobs:
             OMNI_COMPONENT_VERSION=${{ steps.meta.outputs.version }}
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: ${{ inputs.docker_context }}
           file: ${{ inputs.docker_file }}

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -69,11 +69,11 @@ jobs:
       # Add support for more platforms with QEMU (optional)
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action


### PR DESCRIPTION
Upgrade actions in build image to fix warnings
- docker/setup-qemu-action  to v3
- docker/setup-buildx-action  to v3
- actions/checkout to v4
- docker/build-push-action to v5
-  docker/login-action to v3
- docker/metadata-action to v5

test passed: https://github.com/Wiredcraft/elevation/actions/runs/11657511491