### PR TITLE
remove edge tag when branch is develop

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -86,7 +86,6 @@ jobs:
             type=ref,event=pr
             type=ref,event=branch
             type=ref,event=tag
-            type=edge,branch=develop
 
       - name: Login to PrivateRegistry
         # https://github.com/actions/runner/issues/1483


### PR DESCRIPTION
when the branch is `develop`, there will be two tags, `edge` and `develop`, which will cause vulnerability scanning to fail, so remove edge tag